### PR TITLE
feat: Admin Applications View – Backend & Frontend (#186)

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -65,17 +65,20 @@
           "defaultConfiguration": "production"
         },
         "serve": {
-          "builder": "@angular/build:dev-server",
-          "configurations": {
-            "production": {
-              "buildTarget": "campus-platform-ui:build:production"
-            },
-            "development": {
-              "buildTarget": "campus-platform-ui:build:development"
-            }
-          },
-          "defaultConfiguration": "development"
-        },
+  "builder": "@angular/build:dev-server",
+  "options": {
+    "proxyConfig": "proxy.conf.json"
+  },
+  "configurations": {
+    "production": {
+      "buildTarget": "campus-platform-ui:build:production"
+    },
+    "development": {
+      "buildTarget": "campus-platform-ui:build:development"
+    }
+  },
+         "defaultConfiguration": "development"
+         },
         "test": {
           "builder": "@angular/build:unit-test"
         }

--- a/proxy.conf.json
+++ b/proxy.conf.json
@@ -1,0 +1,7 @@
+{
+  "/api": {
+    "target": "http://localhost:8080",
+    "secure": false,
+    "changeOrigin": true
+  }
+}

--- a/public/i18n/de.json
+++ b/public/i18n/de.json
@@ -28,7 +28,8 @@
       "academicStructure": "Akademische Struktur",
       "roomManagement": "Raumverwaltung",
       "eventManagement": "Veranstaltungsmanagement",
-      "examManagement": "Prüfungsmanagement"
+      "examManagement": "Prüfungsmanagement",
+      "applications": "Bewerbungen"
     },
     "lecturer": {
       "home": "Home",

--- a/public/i18n/de.json
+++ b/public/i18n/de.json
@@ -29,7 +29,8 @@
       "roomManagement": "Raumverwaltung",
       "eventManagement": "Veranstaltungsmanagement",
       "examManagement": "Prüfungsmanagement",
-      "applications": "Bewerbungen"
+      "applications": "Bewerbungen",
+      "holidays": "Ferien & Schließzeiten"
     },
     "lecturer": {
       "home": "Home",

--- a/src/app/features/admin/admin.routes.ts
+++ b/src/app/features/admin/admin.routes.ts
@@ -7,6 +7,8 @@ import {ExamManagement} from './exam-management/exam-management';
 import {AcademicStructure} from './academic-structure/academic-structure';
 import {CourseSeriesDetails} from './event-management/course-series-details/course-series-details';
 import { AdminApplications } from './applications/applications';
+import { Holidays } from './holidays/holidays';
+
 
 export const adminRoutes: Routes = [
   {
@@ -41,4 +43,9 @@ export const adminRoutes: Routes = [
   path: 'applications',
   component: AdminApplications
 },
+{
+  path: 'holidays',
+  component: Holidays
+},
+
 ];

--- a/src/app/features/admin/applications/applications.html
+++ b/src/app/features/admin/applications/applications.html
@@ -1,45 +1,70 @@
 <div class="applications-page">
-  <div class="header">
-    <h1>Bewerbungsverwaltung</h1>
-    <p>Eingehende Bewerbungen einsehen und bearbeiten</p>
-  </div>
 
-  <div class="stats-row">
-    <div class="stat pending">⏳ {{ pending }} Ausstehend</div>
-    <div class="stat accepted">✅ {{ accepted }} Angenommen</div>
-    <div class="stat rejected">❌ {{ rejected }} Abgelehnt</div>
-  </div>
+  <div class="loading" *ngIf="loading()">Daten werden geladen…</div>
+  <div class="error" *ngIf="error()">{{ error() }}</div>
 
-  <div class="table-card">
-    <table>
-      <thead>
-        <tr>
-          <th>Student</th>
-          <th>Matrikelnr.</th>
-          <th>Studiengang</th>
-          <th>Datum</th>
-          <th>Status</th>
-          <th>Aktionen</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr *ngFor="let app of applications">
-          <td>{{ app.studentName }}</td>
-          <td>{{ app.studentNumber }}</td>
-          <td>{{ app.program }}</td>
-          <td>{{ app.date }}</td>
-          <td>
-            <span class="badge" [ngClass]="app.status">
-              {{ app.status === 'pending' ? 'Ausstehend' : app.status === 'accepted' ? 'Angenommen' : 'Abgelehnt' }}
-            </span>
-          </td>
-          <td class="actions">
-            <button *ngIf="app.status === 'pending'" class="btn-accept" (click)="accept(app.id)">✓</button>
-            <button *ngIf="app.status === 'pending'" class="btn-reject" (click)="reject(app.id)">✗</button>
-            <span *ngIf="app.status !== 'pending'" class="done">–</span>
-          </td>
-        </tr>
-      </tbody>
-    </table>
+  <div *ngIf="!loading()">
+
+    <div class="header">
+      <h1>Bewerbungsverwaltung</h1>
+      <p>Verwalte eingehende Studiengangsbewerbungen</p>
+    </div>
+
+    <div class="stats-row">
+      <div class="stat-card pending-card">
+        <span class="stat-value">{{ pending() }}</span>
+        <span class="stat-label">Ausstehend</span>
+      </div>
+      <div class="stat-card accepted-card">
+        <span class="stat-value">{{ accepted() }}</span>
+        <span class="stat-label">Angenommen</span>
+      </div>
+      <div class="stat-card rejected-card">
+        <span class="stat-value">{{ rejected() }}</span>
+        <span class="stat-label">Abgelehnt</span>
+      </div>
+    </div>
+
+    <div class="table-card">
+      <table>
+        <thead>
+          <tr>
+            <th>Student</th>
+            <th>E-Mail</th>
+            <th>Studiengang</th>
+            <th>Priorität</th>
+            <th>Datum</th>
+            <th>Status</th>
+            <th>Aktionen</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr *ngFor="let app of applications()">
+            <td>{{ app.studentName }}</td>
+            <td>{{ app.studentEmail }}</td>
+            <td>{{ app.programName }}</td>
+            <td>{{ app.priority }}</td>
+            <td>{{ app.createdAt | date:'dd.MM.yyyy' }}</td>
+            <td>
+              <span class="badge" [ngClass]="{
+                'badge-pending': app.status === 'PENDING',
+                'badge-accepted': app.status === 'ACCEPTED',
+                'badge-rejected': app.status === 'REJECTED'
+              }">
+                {{ app.status === 'PENDING' ? 'Ausstehend' : app.status === 'ACCEPTED' ? 'Angenommen' : 'Abgelehnt' }}
+              </span>
+            </td>
+            <td class="actions">
+              <button class="btn-accept" (click)="accept(app.id)" [disabled]="app.status !== 'PENDING'">✓</button>
+              <button class="btn-reject" (click)="reject(app.id)" [disabled]="app.status !== 'PENDING'">✕</button>
+            </td>
+          </tr>
+          <tr *ngIf="applications().length === 0">
+            <td colspan="7" class="empty">Keine Bewerbungen vorhanden.</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
   </div>
 </div>

--- a/src/app/features/admin/applications/applications.scss
+++ b/src/app/features/admin/applications/applications.scss
@@ -1,92 +1,119 @@
 .applications-page {
   padding: 2rem;
-  background: #f0f4f8;
-  min-height: 100vh;
+}
 
-  .header {
-    margin-bottom: 1.5rem;
-    h1 { font-size: 2rem; margin: 0; }
-    p { color: #666; margin: 0.25rem 0 0; }
+.header {
+  margin-bottom: 1.5rem;
+
+  h1 {
+    font-size: 2rem;
+    margin: 0;
   }
 
-  .stats-row {
-    display: flex;
-    gap: 1rem;
-    margin-bottom: 1.5rem;
+  p {
+    color: #666;
+    margin: 0.25rem 0 0;
+  }
+}
 
-    .stat {
-      background: white;
-      padding: 0.75rem 1.5rem;
-      border-radius: 8px;
-      font-size: 0.95rem;
-      box-shadow: 0 2px 6px rgba(0,0,0,0.05);
-      &.pending { border-left: 4px solid #f39c12; }
-      &.accepted { border-left: 4px solid #27ae60; }
-      &.rejected { border-left: 4px solid #e74c3c; }
+.stats-row {
+  display: flex;
+  gap: 1rem;
+  margin-bottom: 2rem;
+}
+
+.stat-card {
+  flex: 1;
+  padding: 1.25rem;
+  border-radius: 12px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background: white;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.05);
+
+  .stat-value {
+    font-size: 2rem;
+    font-weight: 700;
+  }
+
+  .stat-label {
+    font-size: 0.85rem;
+    color: #666;
+  }
+
+  &.pending-card .stat-value { color: #f59e0b; }
+  &.accepted-card .stat-value { color: #10b981; }
+  &.rejected-card .stat-value { color: #ef4444; }
+}
+
+.table-card {
+  background: white;
+  border-radius: 12px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.05);
+  overflow: hidden;
+
+  table {
+    width: 100%;
+    border-collapse: collapse;
+
+    th {
+      background: #f8fafc;
+      padding: 0.75rem 1rem;
+      text-align: left;
+      font-size: 0.85rem;
+      color: #666;
+      border-bottom: 1px solid #e2e8f0;
+    }
+
+    td {
+      padding: 0.75rem 1rem;
+      border-bottom: 1px solid #f1f5f9;
+      font-size: 0.9rem;
+    }
+  }
+}
+
+.badge {
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 500;
+
+  &.badge-pending  { background: #fef3c7; color: #92400e; }
+  &.badge-accepted { background: #d1fae5; color: #065f46; }
+  &.badge-rejected { background: #fee2e2; color: #991b1b; }
+}
+
+.actions {
+  display: flex;
+  gap: 0.5rem;
+
+  button {
+    padding: 0.3rem 0.6rem;
+    border: none;
+    border-radius: 6px;
+    cursor: pointer;
+    font-weight: bold;
+
+    &:disabled {
+      opacity: 0.3;
+      cursor: not-allowed;
     }
   }
 
-  .table-card {
-    background: white;
-    border-radius: 12px;
-    box-shadow: 0 2px 8px rgba(0,0,0,0.05);
-    overflow: hidden;
+  .btn-accept { background: #d1fae5; color: #065f46; }
+  .btn-reject { background: #fee2e2; color: #991b1b; }
+}
 
-    table {
-      width: 100%;
-      border-collapse: collapse;
+.empty {
+  text-align: center;
+  color: #999;
+  padding: 2rem;
+}
 
-      th {
-        background: #f8f9ff;
-        padding: 0.75rem 1rem;
-        text-align: left;
-        font-size: 0.85rem;
-        color: #888;
-        border-bottom: 1px solid #eee;
-      }
-
-      td {
-        padding: 0.75rem 1rem;
-        border-bottom: 1px solid #f5f5f5;
-        font-size: 0.9rem;
-      }
-    }
-  }
-
-  .badge {
-    padding: 0.25rem 0.75rem;
-    border-radius: 20px;
-    font-size: 0.8rem;
-    font-weight: 600;
-    &.pending { background: #fff3cd; color: #856404; }
-    &.accepted { background: #d4edda; color: #155724; }
-    &.rejected { background: #f8d7da; color: #721c24; }
-  }
-
-  .actions {
-    display: flex;
-    gap: 0.5rem;
-
-    .btn-accept {
-      background: #27ae60;
-      color: white;
-      border: none;
-      border-radius: 6px;
-      padding: 0.3rem 0.6rem;
-      cursor: pointer;
-      &:hover { background: #219a52; }
-    }
-
-    .btn-reject {
-      background: #e74c3c;
-      color: white;
-      border: none;
-      border-radius: 6px;
-      padding: 0.3rem 0.6rem;
-      cursor: pointer;
-      &:hover { background: #c0392b; }
-    }
-
-    .done { color: #aaa; }
-  }
+.loading, .error {
+  padding: 2rem;
+  text-align: center;
+  color: #666;
 }

--- a/src/app/features/admin/applications/applications.ts
+++ b/src/app/features/admin/applications/applications.ts
@@ -1,15 +1,16 @@
-import { Component } from '@angular/core';
+import { Component, signal, computed } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { HttpClient } from '@angular/common/http';
 
-type AppStatus = 'pending' | 'accepted' | 'rejected';
-
-interface Application {
+interface AdminApplication {
   id: number;
   studentName: string;
-  studentNumber: string;
-  program: string;
-  date: string;
-  status: AppStatus;
+  studentEmail: string;
+  programName: string;
+  status: string;
+  priority: number;
+  motivation: string;
+  createdAt: string;
 }
 
 @Component({
@@ -19,25 +20,43 @@ interface Application {
   styleUrl: './applications.scss',
 })
 export class AdminApplications {
-  applications: Application[] = [
-    { id: 1, studentName: 'Max Mustermann', studentNumber: 'S10001', program: 'Wirtschaftsinformatik', date: '10.04.2026', status: 'pending' },
-    { id: 2, studentName: 'Anna Schmidt', studentNumber: 'S10002', program: 'Data Science', date: '11.04.2026', status: 'pending' },
-    { id: 3, studentName: 'Lukas Bauer', studentNumber: 'S10003', program: 'Informatik', date: '09.04.2026', status: 'accepted' },
-    { id: 4, studentName: 'Sara Yilmaz', studentNumber: 'S10004', program: 'BWL', date: '08.04.2026', status: 'rejected' },
-    { id: 5, studentName: 'Tom Fischer', studentNumber: 'S10005', program: 'Digital Marketing', date: '12.04.2026', status: 'pending' },
-  ];
+  applications = signal<AdminApplication[]>([]);
+  loading = signal(true);
+  error = signal<string | null>(null);
 
-  accept(id: number): void {
-    const app = this.applications.find(a => a.id === id);
-    if (app) app.status = 'accepted';
+  constructor(private http: HttpClient) {
+    this.load();
   }
 
-  reject(id: number): void {
-    const app = this.applications.find(a => a.id === id);
-    if (app) app.status = 'rejected';
+  load() {
+    this.loading.set(true);
+    this.http.get<AdminApplication[]>('/api/admin/applications').subscribe({
+      next: (data) => {
+        this.applications.set(data);
+        this.loading.set(false);
+      },
+      error: () => {
+        this.error.set('Bewerbungen konnten nicht geladen werden.');
+        this.loading.set(false);
+      }
+    });
   }
 
-  get pending() { return this.applications.filter(a => a.status === 'pending').length; }
-  get accepted() { return this.applications.filter(a => a.status === 'accepted').length; }
-  get rejected() { return this.applications.filter(a => a.status === 'rejected').length; }
+  updateStatus(id: number, status: string) {
+    this.http.patch<AdminApplication>(`/api/admin/applications/${id}/status?status=${status}`, {}).subscribe({
+      next: (updated) => {
+        this.applications.update(apps =>
+          apps.map(a => a.id === id ? updated : a)
+        );
+      },
+      error: () => this.error.set('Status konnte nicht aktualisiert werden.')
+    });
+  }
+
+  accept(id: number) { this.updateStatus(id, 'ACCEPTED'); }
+  reject(id: number) { this.updateStatus(id, 'REJECTED'); }
+
+  pending = computed(() => this.applications().filter(a => a.status === 'PENDING').length);
+  accepted = computed(() => this.applications().filter(a => a.status === 'ACCEPTED').length);
+  rejected = computed(() => this.applications().filter(a => a.status === 'REJECTED').length);
 }

--- a/src/app/features/admin/holidays/holidays.html
+++ b/src/app/features/admin/holidays/holidays.html
@@ -48,7 +48,7 @@
         </tr>
       </thead>
       <tbody>
-        <tr *ngFor="let h of holidays">
+          <tr *ngFor="let h of holidays()">
           <td>{{ h.name }}</td>
           <td>
             <span class="badge" [ngClass]="h.type">

--- a/src/app/features/admin/holidays/holidays.ts
+++ b/src/app/features/admin/holidays/holidays.ts
@@ -1,6 +1,7 @@
-import { Component } from '@angular/core';
+import { Component, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
+import { HttpClient } from '@angular/common/http';
 
 interface Holiday {
   id: number;
@@ -18,27 +19,46 @@ interface Holiday {
 })
 export class Holidays {
   showForm = false;
+  holidays = signal<Holiday[]>([]);
+  loading = signal(true);
+  error = signal<string | null>(null);
 
   newHoliday = { name: '', startDate: '', endDate: '', type: 'holiday' as 'holiday' | 'closed' };
 
-  holidays: Holiday[] = [
-    { id: 1, name: 'Ostern', startDate: '2026-04-03', endDate: '2026-04-06', type: 'holiday' },
-    { id: 2, name: 'Tag der Arbeit', startDate: '2026-05-01', endDate: '2026-05-01', type: 'holiday' },
-    { id: 3, name: 'Pfingsten', startDate: '2026-05-24', endDate: '2026-05-25', type: 'holiday' },
-    { id: 4, name: 'Wartungsarbeiten', startDate: '2026-06-15', endDate: '2026-06-15', type: 'closed' },
-  ];
+  constructor(private http: HttpClient) {
+    this.load();
+  }
+
+  load() {
+    this.loading.set(true);
+    this.http.get<Holiday[]>('/api/admin/holidays').subscribe({
+      next: (data) => {
+        this.holidays.set(data);
+        this.loading.set(false);
+      },
+      error: () => {
+        this.error.set('Fehler beim Laden der Einträge.');
+        this.loading.set(false);
+      }
+    });
+  }
 
   add(): void {
     if (!this.newHoliday.name || !this.newHoliday.startDate || !this.newHoliday.endDate) return;
-    this.holidays.push({
-      id: Date.now(),
-      ...this.newHoliday
+    this.http.post<Holiday>('/api/admin/holidays', this.newHoliday).subscribe({
+      next: (created) => {
+        this.holidays.update(list => [...list, created]);
+        this.newHoliday = { name: '', startDate: '', endDate: '', type: 'holiday' };
+        this.showForm = false;
+      },
+      error: () => this.error.set('Fehler beim Hinzufügen.')
     });
-    this.newHoliday = { name: '', startDate: '', endDate: '', type: 'holiday' };
-    this.showForm = false;
   }
 
   delete(id: number): void {
-    this.holidays = this.holidays.filter(h => h.id !== id);
+    this.http.delete(`/api/admin/holidays/${id}`).subscribe({
+      next: () => this.holidays.update(list => list.filter(h => h.id !== id)),
+      error: () => this.error.set('Fehler beim Löschen.')
+    });
   }
 }

--- a/src/app/shared/components/navigation/navigation.ts
+++ b/src/app/shared/components/navigation/navigation.ts
@@ -42,7 +42,8 @@ const NAVIGATION_CONFIG: Record<string, NavLink[]> = {
     { path: '/admin/exam-management', label: 'navigation.admin.examManagement', icon: 'insert_chart', exact: false },
 { path: '/admin/applications', label: 'navigation.admin.applications', icon: 'assignment', exact: false },
     { path: '/admin/lecturer-absences', label: 'nav.lecturerAbsences', icon: 'event_busy', exact: false },
-    { path: '/admin/job-postings', label: 'nav.jobPostings', icon: 'work_outline', exact: false }
+    { path: '/admin/job-postings', label: 'nav.jobPostings', icon: 'work_outline', exact: false },
+    { path: '/admin/holidays', label: 'navigation.admin.holidays', icon: 'beach_access', exact: false },
   ],
   [UserRole.Lecturer]: [
     { path: '/lecturer', label: 'navigation.lecturer.home', icon: 'home', exact: true },

--- a/src/app/shared/components/navigation/navigation.ts
+++ b/src/app/shared/components/navigation/navigation.ts
@@ -37,7 +37,12 @@ const NAVIGATION_CONFIG: Record<string, NavLink[]> = {
     { path: '/admin/academic-structure', label: 'navigation.admin.academicStructure', icon: 'school', exact: false },
     { path: '/admin/room-management', label: 'navigation.admin.roomManagement', icon: 'room_preferences', exact: false },
     { path: '/admin/event-management', label: 'navigation.admin.eventManagement', icon: 'event', exact: false },
+<<<<<<< Updated upstream
     { path: '/admin/exam-management', label: 'navigation.admin.examManagement', icon: 'insert_chart', exact: false }
+=======
+    { path: '/admin/exam-management', label: 'navigation.admin.examManagement', icon: 'insert_chart', exact: false },
+    { path: '/admin/applications', label: 'navigation.admin.applications', icon: 'assignment', exact: false },
+>>>>>>> Stashed changes
   ],
   [UserRole.Lecturer]: [
     { path: '/lecturer', label: 'navigation.lecturer.home', icon: 'home', exact: true },

--- a/src/app/shared/components/navigation/navigation.ts
+++ b/src/app/shared/components/navigation/navigation.ts
@@ -37,12 +37,8 @@ const NAVIGATION_CONFIG: Record<string, NavLink[]> = {
     { path: '/admin/academic-structure', label: 'navigation.admin.academicStructure', icon: 'school', exact: false },
     { path: '/admin/room-management', label: 'navigation.admin.roomManagement', icon: 'room_preferences', exact: false },
     { path: '/admin/event-management', label: 'navigation.admin.eventManagement', icon: 'event', exact: false },
-<<<<<<< Updated upstream
-    { path: '/admin/exam-management', label: 'navigation.admin.examManagement', icon: 'insert_chart', exact: false }
-=======
     { path: '/admin/exam-management', label: 'navigation.admin.examManagement', icon: 'insert_chart', exact: false },
-    { path: '/admin/applications', label: 'navigation.admin.applications', icon: 'assignment', exact: false },
->>>>>>> Stashed changes
+{ path: '/admin/applications', label: 'navigation.admin.applications', icon: 'assignment', exact: false },
   ],
   [UserRole.Lecturer]: [
     { path: '/lecturer', label: 'navigation.lecturer.home', icon: 'home', exact: true },
@@ -53,7 +49,8 @@ const NAVIGATION_CONFIG: Record<string, NavLink[]> = {
     { path: '/student', label: 'navigation.student.home', icon: 'home', exact: true },
     { path: '/student/timetable', label: 'navigation.student.timetable', icon: 'calendar_month', exact: false },
     { path: '/student/grades', label: 'navigation.student.grades', icon: 'star_outline', activeIcon: 'star', exact: false },
-    { path: '/student/submissions', label: 'navigation.student.submissions', icon: 'task', exact: false }
+    { path: '/student/submissions', label: 'navigation.student.submissions', icon: 'task', exact: false },
+    { path: '/student/applications', label: 'navigation.student.applications', icon: 'school', exact: false }
   ]
 }
 


### PR DESCRIPTION
Was wurde umgesetzt?
Implementierung der Admin-Ansicht für Studiengangsbewerbungen. Admins können alle eingegangenen Bewerbungen einsehen und deren Status auf Angenommen oder Abgelehnt setzen.
Änderungen Backend (campus-platform-service):

AdminApplicationResponse.java – neues DTO mit Studentenname, E-Mail, Studiengang, Status, Priorität
ApplicationService.java – zwei neue Methoden: getAllApplications() und updateStatus()
AdminController.java – zwei neue Endpunkte:

GET /api/admin/applications – alle Bewerbungen abrufen
PATCH /api/admin/applications/{id}/status – Status aktualisieren (ACCEPTED/REJECTED)



Änderungen Frontend (campus-platform-ui):

applications.ts – Backend-Anbindung via HttpClient, Signals für reaktiven State, Annehmen/Ablehnen-Logik
applications.html – Tabelle mit Statusbadges und Aktions-Buttons
applications.scss – Styling mit Stat-Karten und Tabelle
navigation.ts – Nav-Link für Admin-Bereich ergänzt
de.json – Übersetzungskey navigation.admin.applications
admin.routes.ts – Route für /admin/applications bereits vorhanden

Closes #186