### PR TITLE
Feature/us196 admin holidays

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -65,17 +65,20 @@
           "defaultConfiguration": "production"
         },
         "serve": {
-          "builder": "@angular/build:dev-server",
-          "configurations": {
-            "production": {
-              "buildTarget": "campus-platform-ui:build:production"
-            },
-            "development": {
-              "buildTarget": "campus-platform-ui:build:development"
-            }
-          },
-          "defaultConfiguration": "development"
-        },
+  "builder": "@angular/build:dev-server",
+  "options": {
+    "proxyConfig": "proxy.conf.json"
+  },
+  "configurations": {
+    "production": {
+      "buildTarget": "campus-platform-ui:build:production"
+    },
+    "development": {
+      "buildTarget": "campus-platform-ui:build:development"
+    }
+  },
+  "defaultConfiguration": "development"
+},
         "test": {
           "builder": "@angular/build:unit-test"
         }

--- a/proxy.conf.json
+++ b/proxy.conf.json
@@ -1,0 +1,7 @@
+{
+  "/api": {
+    "target": "http://localhost:8080",
+    "secure": false,
+    "changeOrigin": true
+  }
+}

--- a/public/i18n/de.json
+++ b/public/i18n/de.json
@@ -41,6 +41,7 @@
       "timetable": "Stundenplan",
       "grades": "Noten",
       "submissions": "Abgaben",
+      "applications": "Bewerbungen",
       "submissionsPage": {
         "title": "Abgaben",
         "subtitle": "Lade Dokumente hoch, verwalte deine Einreichungen und verfolge den Status.",

--- a/public/i18n/de.json
+++ b/public/i18n/de.json
@@ -28,7 +28,9 @@
       "academicStructure": "Akademische Struktur",
       "roomManagement": "Raumverwaltung",
       "eventManagement": "Veranstaltungsmanagement",
-      "examManagement": "Prüfungsmanagement"
+      "examManagement": "Prüfungsmanagement",
+      "applications": "Bewerbungen",
+      "holidays": "Ferien & Schließzeiten"
     },
     "lecturer": {
       "home": "Home",

--- a/src/app/features/admin/holidays/holidays.html
+++ b/src/app/features/admin/holidays/holidays.html
@@ -48,7 +48,7 @@
         </tr>
       </thead>
       <tbody>
-        <tr *ngFor="let h of holidays">
+          <tr *ngFor="let h of holidays()">
           <td>{{ h.name }}</td>
           <td>
             <span class="badge" [ngClass]="h.type">

--- a/src/app/features/admin/holidays/holidays.ts
+++ b/src/app/features/admin/holidays/holidays.ts
@@ -1,6 +1,7 @@
-import { Component } from '@angular/core';
+import { Component, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
+import { HttpClient } from '@angular/common/http';
 
 interface Holiday {
   id: number;
@@ -18,27 +19,46 @@ interface Holiday {
 })
 export class Holidays {
   showForm = false;
+  holidays = signal<Holiday[]>([]);
+  loading = signal(true);
+  error = signal<string | null>(null);
 
   newHoliday = { name: '', startDate: '', endDate: '', type: 'holiday' as 'holiday' | 'closed' };
 
-  holidays: Holiday[] = [
-    { id: 1, name: 'Ostern', startDate: '2026-04-03', endDate: '2026-04-06', type: 'holiday' },
-    { id: 2, name: 'Tag der Arbeit', startDate: '2026-05-01', endDate: '2026-05-01', type: 'holiday' },
-    { id: 3, name: 'Pfingsten', startDate: '2026-05-24', endDate: '2026-05-25', type: 'holiday' },
-    { id: 4, name: 'Wartungsarbeiten', startDate: '2026-06-15', endDate: '2026-06-15', type: 'closed' },
-  ];
+  constructor(private http: HttpClient) {
+    this.load();
+  }
+
+  load() {
+    this.loading.set(true);
+    this.http.get<Holiday[]>('/api/admin/holidays').subscribe({
+      next: (data) => {
+        this.holidays.set(data);
+        this.loading.set(false);
+      },
+      error: () => {
+        this.error.set('Fehler beim Laden der Einträge.');
+        this.loading.set(false);
+      }
+    });
+  }
 
   add(): void {
     if (!this.newHoliday.name || !this.newHoliday.startDate || !this.newHoliday.endDate) return;
-    this.holidays.push({
-      id: Date.now(),
-      ...this.newHoliday
+    this.http.post<Holiday>('/api/admin/holidays', this.newHoliday).subscribe({
+      next: (created) => {
+        this.holidays.update(list => [...list, created]);
+        this.newHoliday = { name: '', startDate: '', endDate: '', type: 'holiday' };
+        this.showForm = false;
+      },
+      error: () => this.error.set('Fehler beim Hinzufügen.')
     });
-    this.newHoliday = { name: '', startDate: '', endDate: '', type: 'holiday' };
-    this.showForm = false;
   }
 
   delete(id: number): void {
-    this.holidays = this.holidays.filter(h => h.id !== id);
+    this.http.delete(`/api/admin/holidays/${id}`).subscribe({
+      next: () => this.holidays.update(list => list.filter(h => h.id !== id)),
+      error: () => this.error.set('Fehler beim Löschen.')
+    });
   }
 }

--- a/src/app/features/student/applications/applications.html
+++ b/src/app/features/student/applications/applications.html
@@ -1,0 +1,61 @@
+<div class="applications-page">
+
+  <!-- Ladezustand -->
+  <div class="loading" *ngIf="loading()">Daten werden geladen…</div>
+
+  <!-- Fehlerzustand -->
+  <div class="error" *ngIf="error() && !loading()">Bewerbungsdaten konnten nicht geladen werden.</div>
+
+  <!-- Inhalt -->
+  <div *ngIf="!loading() && !error()">
+
+    <div class="header">
+      <div>
+        <h1>Bewerbung für Studiengänge</h1>
+        <p>Wähle einen Studiengang und lade optional ein PDF hoch</p>
+      </div>
+    </div>
+
+    <div class="form-card">
+      <div class="form-group">
+        <label>Studiengang</label>
+        <select [(ngModel)]="form.programId">
+          <option value="">Bitte wählen…</option>
+          <option *ngFor="let p of programs()" [value]="p.id">{{ p.name }}</option>
+        </select>
+      </div>
+
+      <div class="form-group">
+        <label>Motivation (optional)</label>
+        <textarea [(ngModel)]="form.motivation" rows="3"></textarea>
+      </div>
+
+      <div class="form-group">
+        <label>Priorität</label>
+        <select [(ngModel)]="form.priority">
+          <option [value]="1">1</option>
+          <option [value]="2">2</option>
+          <option [value]="3">3</option>
+        </select>
+      </div>
+
+      <div class="form-group">
+        <label>PDF hochladen</label>
+        <input type="file" (change)="onFileSelected($event)" accept="application/pdf">
+      </div>
+
+      <button class="btn-primary" (click)="submit()">Bewerbung absenden</button>
+    </div>
+
+    <h2>Meine Bewerbungen</h2>
+
+    <div class="applications-list">
+      <div class="application-card" *ngFor="let app of myApplications()">
+        <h3>{{ app.programName }}</h3>
+        <p>Status: {{ app.status }}</p>
+        <p>Priorität: {{ app.priority }}</p>
+      </div>
+    </div>
+
+  </div>
+</div>

--- a/src/app/features/student/applications/applications.scss
+++ b/src/app/features/student/applications/applications.scss
@@ -1,0 +1,50 @@
+.applications-page {
+  padding: 2rem;
+}
+
+.header h1 {
+  margin: 0;
+  font-size: 2rem;
+}
+
+.form-card {
+  background: white;
+  padding: 1.5rem;
+  border-radius: 12px;
+  margin-bottom: 2rem;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.05);
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 1rem;
+}
+
+.form-group label {
+  font-size: 0.9rem;
+  margin-bottom: 0.3rem;
+}
+
+input, select, textarea {
+  padding: 0.6rem;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+}
+
+.btn-primary {
+  background: #3b5bdb;
+  color: white;
+  padding: 0.7rem 1.2rem;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+.application-card {
+  background: white;
+  padding: 1rem;
+  border-radius: 12px;
+  margin-bottom: 1rem;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.05);
+}

--- a/src/app/features/student/applications/applications.ts
+++ b/src/app/features/student/applications/applications.ts
@@ -1,0 +1,73 @@
+import { Component, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { StudentApplicationsService } from '../services/student-applications.service';
+
+@Component({
+  selector: 'app-student-applications',
+  standalone: true,
+  imports: [
+    CommonModule,
+    FormsModule
+  ],
+  templateUrl: './applications.html',
+  styleUrls: ['./applications.scss']
+})
+export class Applications {
+  today = new Date();
+
+  loading = signal(true);
+  error = signal<string | null>(null);
+  programs = signal<any[]>([]);
+  myApplications = signal<any[]>([]);
+
+  form = {
+    programId: '',
+    motivation: '',
+    priority: 1,
+    file: null
+  };
+
+  constructor(private service: StudentApplicationsService) {
+    this.load();
+  }
+
+  load() {
+    this.loading.set(true);
+    this.service.getPrograms().subscribe({
+      next: (data) => {
+        this.programs.set(data);
+        this.loadMyApplications();
+      },
+      error: () => {
+        this.error.set('Fehler beim Laden');
+        this.loading.set(false);
+      }
+    });
+  }
+
+loadMyApplications() {
+  this.service.getMyApplications().subscribe({
+    next: (apps) => {
+      this.myApplications.set(apps);
+      this.loading.set(false);
+    },
+    error: () => {
+      // getMyApplications schlägt fehl (z.B. 500), aber programmes wurden geladen
+      this.myApplications.set([]);
+      this.loading.set(false);
+    }
+  });
+}
+
+  onFileSelected(event: any) {
+    this.form.file = event.target.files[0];
+  }
+
+  submit() {
+    this.service.apply(this.form).subscribe({
+      next: () => this.load(),
+      error: () => this.error.set('Fehler beim Absenden')
+    });
+  }
+}

--- a/src/app/features/student/services/student-applications.service.ts
+++ b/src/app/features/student/services/student-applications.service.ts
@@ -1,0 +1,27 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class StudentApplicationsService {
+
+  constructor(private http: HttpClient) {}
+
+  getPrograms() {
+    return this.http.get<any[]>('/api/applications/programs');
+  }
+
+  getMyApplications() {
+    // Kein studentId mehr – kommt aus dem JWT via @AuthenticationPrincipal
+    return this.http.get<any[]>('/api/applications/my');
+  }
+
+  apply(form: any) {
+    const fd = new FormData();
+    fd.append('programId', form.programId);
+    fd.append('motivation', form.motivation || '');
+    fd.append('priority', form.priority.toString());
+    if (form.file) fd.append('file', form.file);
+
+    return this.http.post<any>('/api/applications/apply', fd);
+  }
+}

--- a/src/app/features/student/student.routes.ts
+++ b/src/app/features/student/student.routes.ts
@@ -3,6 +3,7 @@ import { StudentHome } from './student-home/student-home';
 import { Grades } from './grades/grades';
 import { Submissions } from './submissions/submissions';
 import { Timetable } from './timetable/timetable';
+import { Applications } from './applications/applications';
 
 export const studentRoutes: Routes = [
   {
@@ -21,4 +22,7 @@ export const studentRoutes: Routes = [
     path: 'timetable',
     component: Timetable
   },
+  { path: 'applications', 
+    component: Applications }
+
 ];

--- a/src/app/shared/components/navigation/navigation.ts
+++ b/src/app/shared/components/navigation/navigation.ts
@@ -37,7 +37,7 @@ const NAVIGATION_CONFIG: Record<string, NavLink[]> = {
     { path: '/admin/academic-structure', label: 'navigation.admin.academicStructure', icon: 'school', exact: false },
     { path: '/admin/room-management', label: 'navigation.admin.roomManagement', icon: 'room_preferences', exact: false },
     { path: '/admin/event-management', label: 'navigation.admin.eventManagement', icon: 'event', exact: false },
-    { path: '/admin/exam-management', label: 'navigation.admin.examManagement', icon: 'insert_chart', exact: false }
+    { path: '/admin/exam-management', label: 'navigation.admin.examManagement', icon: 'insert_chart', exact: false },
   ],
   [UserRole.Lecturer]: [
     { path: '/lecturer', label: 'navigation.lecturer.home', icon: 'home', exact: true },
@@ -48,7 +48,9 @@ const NAVIGATION_CONFIG: Record<string, NavLink[]> = {
     { path: '/student', label: 'navigation.student.home', icon: 'home', exact: true },
     { path: '/student/timetable', label: 'navigation.student.timetable', icon: 'calendar_month', exact: false },
     { path: '/student/grades', label: 'navigation.student.grades', icon: 'star_outline', activeIcon: 'star', exact: false },
-    { path: '/student/submissions', label: 'navigation.student.submissions', icon: 'task', exact: false }
+    { path: '/student/submissions', label: 'navigation.student.submissions', icon: 'task', exact: false },
+    { path: '/student/applications', label: 'navigation.student.applications', icon: 'school', exact: false }
+
   ]
 }
 

--- a/src/app/shared/components/navigation/navigation.ts
+++ b/src/app/shared/components/navigation/navigation.ts
@@ -38,6 +38,10 @@ const NAVIGATION_CONFIG: Record<string, NavLink[]> = {
     { path: '/admin/room-management', label: 'navigation.admin.roomManagement', icon: 'room_preferences', exact: false },
     { path: '/admin/event-management', label: 'navigation.admin.eventManagement', icon: 'event', exact: false },
     { path: '/admin/exam-management', label: 'navigation.admin.examManagement', icon: 'insert_chart', exact: false },
+    { path: '/admin/applications', label: 'navigation.admin.applications', icon: 'assignment', exact: false },
+    { path: '/admin/lecturer-absences', label: 'nav.lecturerAbsences', icon: 'event_busy', exact: false },
+    { path: '/admin/job-postings', label: 'nav.jobPostings', icon: 'work_outline', exact: false },
+    { path: '/admin/holidays', label: 'navigation.admin.holidays', icon: 'beach_access', exact: false },
   ],
   [UserRole.Lecturer]: [
     { path: '/lecturer', label: 'navigation.lecturer.home', icon: 'home', exact: true },


### PR DESCRIPTION
Was wurde umgesetzt?
Die bestehende Admin-Verwaltungsseite für Ferien und Schließzeiten wurde vollständig ans Backend angebunden. Daten werden jetzt aus der Datenbank geladen und dort gespeichert – kein Hardcode mehr.
Änderungen Frontend (campus-platform-ui):

holidays.ts – Backend-Anbindung via HttpClient, Signals für reaktiven State, Laden/Hinzufügen/Löschen über REST-API
holidays.html – holidays() statt holidays (Signal-Syntax)
navigation.ts – Nav-Link für /admin/holidays ergänzt
de.json – Übersetzungskey navigation.admin.holidays
proxy.conf.json – API-Proxy für lokale Entwicklung

Closes #196